### PR TITLE
PyGIDeprecation

### DIFF
--- a/iptv.py
+++ b/iptv.py
@@ -15,8 +15,6 @@ import urllib
 
 PATH = os.path.dirname(os.path.realpath(__file__))
 CFG=None
-GObject.threads_init()
-
 
 vlc_process = None
 


### PR DESCRIPTION
Since version 3.11, calling threads_init is no longer needed. See: https://wiki.gnome.org/PyGObject/Threading
  GObject.threads_init()